### PR TITLE
Update make script

### DIFF
--- a/Make.sh
+++ b/Make.sh
@@ -1,23 +1,25 @@
-#!/bin/sh
+#!/bin/bash
 if [ ! $1 ] ; then
-echo "Please specify the code you want to compile by typing :"
-echo "./Make <Your-Code.C>"
-exit 1
+    echo "Please specify the code you want to compile by typing :"
+    echo "$0 <Your-Code.C>"
+    exit 1
 fi
-echo "================================================================"
 
-echo "====> Here are the libraries:" "\n" `root-config --cflags --glibs` -lTMVA "\n"
+echo "================================================================"
+echo "====> Here are the libraries:" $'\n' `root-config --cflags --glibs` -lTMVA $'\n'
 filename=`echo $1 | awk -F"." '{print $1}'`
 exefilename=${filename}.exe
 rm -f $exefilename
 g++ $1  -o $exefilename `root-config --cflags --glibs` -lTMVA
 echo ""
 if [ -e $exefilename ]; then
-echo "====> Created exe file : "
-ls -lrt $exefilename
-echo "====> Done."
+    echo "====> Created exe file : "
+    ls -lrt $exefilename
+    echo "====> Done."
+    echo "================================================================"
+    exit 0
 else
-echo "====> Did not create the exe file!"
+    echo "====> Did not create the exe file!"
+    echo "================================================================"
+    exit 1
 fi
-echo "================================================================"
-


### PR DESCRIPTION
The existing code was trying `echo "\n"`, which doesn't work. It outputs `\n` instead of an actual newline. They need to be wrapped with ANSI C quotes (`$'\n'`), which (according to the manual):

```
Words of the form $'string' are treated specially. The word expands to string, with backslash-escaped characters replaced as specified by the ANSI C standard.
```

Add indentation
Make it so the file sets the proper error code
Replace hard-coded script name with `$0`